### PR TITLE
Symfony packages upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,29 +10,30 @@
     }
   ],
   "require": {
-      "php": ">=8.0",
-      "doctrine/annotations": "^1.14",
-      "doctrine/doctrine-bundle": "^2.8",
-      "doctrine/orm": "^2.14",
-      "elasticsearch/elasticsearch": "^7.1",
-      "symfony/dotenv": "6.3.*",
-      "symfony/expression-language": "6.3.*",
-      "symfony/framework-bundle": "^6.3",
-      "symfony/messenger": "6.3.*",
-      "symfony/property-info": "6.3.*",
-      "symfony/runtime": "6.3.*",
-      "symfony/serializer": "6.3.*",
-      "symfony/validator": "6.3.*",
-      "symfony/yaml": "6.3.*",
-      "ext-simplexml": "*",
-      "symfony/security-bundle": "^6.3",
-      "symfony/finder": "^6.3"
+    "php": ">=8.0",
+    "doctrine/annotations": "^1.14",
+    "doctrine/doctrine-bundle": "^2.8",
+    "doctrine/orm": "^2.14",
+    "elasticsearch/elasticsearch": "^7.1",
+    "symfony/dotenv": "6.4.*",
+    "symfony/expression-language": "6.4.*",
+    "symfony/framework-bundle": "^6.4",
+    "symfony/messenger": "6.4.*",
+    "symfony/property-info": "6.4.*",
+    "symfony/runtime": "6.4.*",
+    "symfony/serializer": "6.4.*",
+    "symfony/validator": "6.4.*",
+    "symfony/yaml": "6.4.*",
+    "ext-simplexml": "*",
+    "symfony/security-bundle": "^6.4",
+    "symfony/finder": "^6.4"
   },
   "require-dev": {
-      "symfony/browser-kit": "6.3.*",
-      "symfony/css-selector": "6.3.*",
-      "symfony/console": "6.3.*",
-      "symfony/phpunit-bridge": "^6.3"
+    "symfony/browser-kit": "6.3.*",
+    "symfony/css-selector": "6.3.*",
+    "symfony/console": "6.3.*",
+    "symfony/phpunit-bridge": "^6.3",
+    "symfony/test-pack": "^1.1"
   },
   "prefer-stable": true,
   "autoload": {
@@ -45,6 +46,9 @@
   "extra": {
     "branch-alias": {
       "dev-master": "1.0-dev"
+    },
+    "symfony": {
+      "require": "6.4.*"
     }
   },
   "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,10 @@
     "symfony/finder": "^6.4"
   },
   "require-dev": {
-    "symfony/browser-kit": "6.3.*",
-    "symfony/css-selector": "6.3.*",
-    "symfony/console": "6.3.*",
-    "symfony/phpunit-bridge": "^6.3",
+    "symfony/browser-kit": "6.4.*",
+    "symfony/css-selector": "6.4.*",
+    "symfony/console": "6.4.*",
+    "symfony/phpunit-bridge": "^6.4",
     "symfony/test-pack": "^1.1"
   },
   "prefer-stable": true,

--- a/tests/Fixtures/app/Model/DummyUser.php
+++ b/tests/Fixtures/app/Model/DummyUser.php
@@ -62,7 +62,7 @@ class DummyUser implements UserInterface
         $this->username = $username;
     }
 
-    public function eraseCredentials()
+    public function eraseCredentials(): void
     {
         $this->password = null;
     }


### PR DESCRIPTION
Upgrading a Minor Version 6.3 to 6.4

- upgraded "symfony/*" packages
- added test-pack dev dependency
- added `void` return type to `eraseCredentials()` method in `tests/Fixtures/app/Model/DummyUser.php`