### PR TITLE
fix(composer): resolve fresh-install failure caused by security-blocked version pins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /.phpunit.result.cache
 /composer.lock
 /bin
+/data
+/tests/Fixtures/app/var
+/tests/Fixtures/app/config/reference.php

--- a/composer.json
+++ b/composer.json
@@ -15,24 +15,24 @@
     "doctrine/doctrine-bundle": "^2.8",
     "doctrine/orm": "^3.4",
     "elasticsearch/elasticsearch": "^7.1",
-    "symfony/dotenv": "7.3.*",
-    "symfony/expression-language": "7.3.*",
+    "symfony/expression-language": "^7.3",
     "symfony/framework-bundle": "^7.3",
-    "symfony/messenger": "7.3.*",
-    "symfony/property-info": "7.3.*",
-    "symfony/runtime": "7.3.*",
-    "symfony/serializer": "7.3.*",
-    "symfony/validator": "7.3.*",
-    "symfony/yaml": "7.3.*",
+    "symfony/messenger": "^7.3",
+    "symfony/property-info": "^7.3",
+    "symfony/serializer": "^7.3",
+    "symfony/validator": "^7.3",
+    "symfony/yaml": "^7.3",
     "ext-simplexml": "*",
     "symfony/security-bundle": "^7.3",
     "symfony/finder": "^7.3"
   },
   "require-dev": {
-    "symfony/browser-kit": "7.3.*",
-    "symfony/css-selector": "7.3.*",
-    "symfony/console": "7.3.*",
+    "symfony/browser-kit": "^7.3",
+    "symfony/css-selector": "^7.3",
+    "symfony/console": "^7.3",
+    "symfony/dotenv": "^7.3",
     "symfony/phpunit-bridge": "^7.3",
+    "symfony/runtime": "^7.3",
     "symfony/test-pack": "1.1.0"
   },
   "prefer-stable": true,
@@ -46,13 +46,11 @@
   "extra": {
     "branch-alias": {
       "dev-master": "1.0-dev"
-    },
-    "symfony": {
-      "require": "7.3.*"
     }
   },
   "conflict": {
-    "symfony/translations-contracts": "<2.0"
+    "symfony/translations-contracts": "<2.0",
+    "symfony/var-exporter": ">=8.0"
   },
   "config": {
     "allow-plugins": {

--- a/tests/Fixtures/app/AppKernel.php
+++ b/tests/Fixtures/app/AppKernel.php
@@ -42,6 +42,6 @@ class AppKernel extends Kernel
         $configDir = $this->getConfigDir();
 
         $container->import($configDir.'/{packages}/*.{php,yaml}');
-        $container->import($configDir.'/*.{php,yaml}');
+        $container->import($configDir.'/*.yaml');
     }
 }


### PR DESCRIPTION
| Q             | A
|---------------|---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Issues        | -
| License       | MIT

## Problem

A clean `composer install` currently fails to resolve dependencies — and so
does CI for any new pull request, since no `composer.lock` is committed:

```
Root composer.json requires symfony/runtime 7.3.*, found symfony/runtime[v7.3.0, ..., v7.3.8]
but these were not loaded, because they are affected by security advisories
```

Composer >= 2.9 refuses to install packages with known security advisories.
The exact `7.3.*` pins only match `symfony/runtime` and `symfony/yaml`
releases that all carry advisories — the patched releases are on 7.4, which
the pins exclude.

## Changes

- Widen all `symfony/*` `7.3.*` pins to `^7.3` so patched 7.4 releases can resolve
- Remove the `extra.symfony.require: 7.3.*` pin
- Move `symfony/dotenv` and `symfony/runtime` to `require-dev` — nothing in `src/` or the test app references them
- Add `conflict: symfony/var-exporter >= 8.0` — `doctrine/orm` allows `^8.0`, so without a cap Composer mixes a Symfony 8 component into the otherwise 7.x stack and Doctrine's LazyGhost proxies fail at kernel boot (`Symfony LazyGhost is not available`)
- Import only `*.yaml` from the test kernel's root config dir — Symfony 7.4 auto-generates `config/reference.php` in debug mode, and re-importing it as application config causes a fatal class redeclaration; generated paths are now gitignored

## Verification

- Fresh dependency resolution succeeds with Composer's security audit enabled — zero advisories (resolves to Symfony 7.4.14)
- `composer validate --strict` passes
- Full PHPUnit suite (24 tests, 53 assertions) passes against Elasticsearch 7.17
- Installs currently working on Symfony 7.3 keep working; they only gain access to patched releases
