### PR TITLE
feat: support Symfony 6.4 and drop abandoned doctrine/annotations

### DIFF
--- a/.github/workflows/tests-matrix.yaml
+++ b/.github/workflows/tests-matrix.yaml
@@ -1,0 +1,43 @@
+name: Tests matrix
+
+on:
+    push:
+        branches: [ master ]
+    pull_request:
+        branches: [ master ]
+
+jobs:
+    tests:
+        runs-on: ubuntu-latest
+        name: PHP ${{ matrix.php }} + Symfony ${{ matrix.symfony }}
+        strategy:
+            fail-fast: false
+            matrix:
+                php: ['8.2', '8.3', '8.4']
+                symfony: ['6.4.*', '7.4.*']
+        steps:
+            - name: Runs Elasticsearch
+              uses: elastic/elastic-github-actions/elasticsearch@master
+              with:
+                  stack-version: '7.17.28'
+            - uses: actions/checkout@v4
+            - uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '${{ matrix.php }}'
+                  coverage: none
+            - name: Install symfony/flex
+              run: |
+                  composer global config --no-plugins allow-plugins.symfony/flex true
+                  composer global require --no-progress --no-scripts symfony/flex
+            - name: Install Dependencies
+              run: composer update -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+              env:
+                  SYMFONY_REQUIRE: ${{ matrix.symfony }}
+            - name: Create Database
+              run: |
+                  mkdir -p data
+                  touch data/database.sqlite
+            - name: Run tests
+              env:
+                  DATABASE_URL: sqlite:///%kernel.project_dir%/data/database.sqlite
+              run: vendor/bin/simple-phpunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Support for Symfony 6.4 (LTS): all `symfony/*` requirements now accept `^6.4 || ^7.0`
+- Tests matrix CI workflow covering PHP 8.2/8.3/8.4 with Symfony 6.4 and 7.4
+
+### Changed
+- `doctrine/annotations` (abandoned upstream) is no longer a dependency; configure loggable classes with the `#[Loggable]` PHP attribute or XML/YAML
+
+### Deprecated
+- `AnnotationLoggableContextCollectionFactory`, to be removed in 2.0; use `AttributeLoggableContextCollectionFactory` with the `#[Loggable]` attribute instead
 - `ElasticsearchClientInterface` and `ElasticsearchServiceInterface`; services now type-hint the interfaces, enabling decoration (#32, thanks @manuel-gamma)
 - PHPStan (level 6) and PHP-CS-Fixer with a dedicated Quality CI workflow
 - `CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md`, and GitHub issue/PR templates

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Making your entity loggable
 To make your entity loggable you need to do the following steps:
 ### 1. Add Loggable attribute to your entity
 
-Add `Locastic\Loggastic\Annotation\Loggable` annotation to your entity and define serialization group name:
+Add the `Locastic\Loggastic\Annotation\Loggable` PHP attribute to your entity and define serialization group name:
 ```php
 <?php
 

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,0 +1,12 @@
+# Upgrading to 2.0
+
+This document collects the breaking changes planned for 2.0. Each entry lists
+the deprecation shipped in a 1.x release so you can migrate before upgrading.
+
+## Metadata
+
+- `AnnotationLoggableContextCollectionFactory` (deprecated since 1.2) is
+  removed. Configure loggable classes with the `#[Loggable]` PHP attribute
+  (handled by `AttributeLoggableContextCollectionFactory`) or with XML/YAML
+  extractors. The `doctrine/annotations` package is no longer a dependency
+  since 1.2.

--- a/composer.json
+++ b/composer.json
@@ -11,28 +11,29 @@
   ],
   "require": {
     "php": ">=8.2",
-    "doctrine/annotations": "^2.0",
     "doctrine/doctrine-bundle": "^2.8",
     "doctrine/orm": "^3.4",
     "elasticsearch/elasticsearch": "^7.1",
-    "symfony/expression-language": "^7.3",
-    "symfony/framework-bundle": "^7.3",
-    "symfony/messenger": "^7.3",
-    "symfony/property-info": "^7.3",
-    "symfony/serializer": "^7.3",
-    "symfony/validator": "^7.3",
-    "symfony/yaml": "^7.3",
+    "symfony/deprecation-contracts": "^3.0",
+    "symfony/expression-language": "^6.4 || ^7.0",
+    "symfony/framework-bundle": "^6.4 || ^7.0",
+    "symfony/messenger": "^6.4 || ^7.0",
+    "symfony/property-info": "^6.4 || ^7.0",
+    "symfony/serializer": "^6.4 || ^7.0",
+    "symfony/validator": "^6.4 || ^7.0",
+    "symfony/yaml": "^6.4 || ^7.0",
     "ext-simplexml": "*",
-    "symfony/security-bundle": "^7.3",
-    "symfony/finder": "^7.3"
+    "symfony/security-bundle": "^6.4 || ^7.0",
+    "symfony/finder": "^6.4 || ^7.0"
   },
   "require-dev": {
-    "symfony/browser-kit": "^7.3",
-    "symfony/css-selector": "^7.3",
-    "symfony/console": "^7.3",
-    "symfony/dotenv": "^7.3",
-    "symfony/phpunit-bridge": "^7.3",
-    "symfony/runtime": "^7.3",
+    "doctrine/annotations": "^2.0",
+    "symfony/browser-kit": "^6.4 || ^7.0",
+    "symfony/css-selector": "^6.4 || ^7.0",
+    "symfony/console": "^6.4 || ^7.0",
+    "symfony/dotenv": "^6.4 || ^7.0",
+    "symfony/phpunit-bridge": "^6.4 || ^7.0",
+    "symfony/runtime": "^6.4 || ^7.0",
     "symfony/test-pack": "1.1.0",
     "phpstan/phpstan": "^2.2",
     "phpstan/phpstan-symfony": "^2.0",
@@ -55,6 +56,9 @@
   "conflict": {
     "symfony/translations-contracts": "<2.0",
     "symfony/var-exporter": ">=8.0"
+  },
+  "suggest": {
+    "doctrine/annotations": "To configure loggable classes with the legacy @Loggable annotation (deprecated, use the PHP attribute instead)"
   },
   "config": {
     "allow-plugins": {

--- a/src/Metadata/LoggableContext/Factory/AnnotationLoggableContextCollectionFactory.php
+++ b/src/Metadata/LoggableContext/Factory/AnnotationLoggableContextCollectionFactory.php
@@ -7,6 +7,9 @@ use Locastic\Loggastic\Annotation\Loggable;
 use Locastic\Loggastic\Metadata\LoggableContext\LoggableContextCollection;
 use Locastic\Loggastic\Util\RecursiveClassIterator;
 
+/**
+ * @deprecated since locastic/loggastic 1.2 and will be removed in 2.0, use AttributeLoggableContextCollectionFactory with the #[Loggable] attribute instead. Requires the abandoned doctrine/annotations package, which is no longer a dependency of this bundle.
+ */
 final class AnnotationLoggableContextCollectionFactory implements LoggableContextCollectionFactoryInterface
 {
     /**
@@ -14,6 +17,7 @@ final class AnnotationLoggableContextCollectionFactory implements LoggableContex
      */
     public function __construct(private readonly LoggableContextCollectionFactoryInterface $decorated, private readonly Reader $reader, private readonly array $loggablePaths)
     {
+        trigger_deprecation('locastic/loggastic', '1.2', 'The "%s" class is deprecated and will be removed in 2.0, use "%s" with the #[Loggable] attribute instead.', self::class, AttributeLoggableContextCollectionFactory::class);
     }
 
     public function create(): LoggableContextCollection


### PR DESCRIPTION
| Q             | A
|---------------|---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Issues        | -
| License       | MIT

## Problem

The bundle only accepts Symfony `^7.3`, which locks out every app on Symfony 6.4 LTS (supported until November 2027) and forces a release per Symfony minor. It also requires `doctrine/annotations`, which is abandoned upstream, even though the only class using it (`AnnotationLoggableContextCollectionFactory`) is not registered as a service and the `#[Loggable]` PHP attribute has been the documented way to configure loggable classes.

## Changes

- Widen all `symfony/*` constraints to `^6.4 || ^7.0`
- Remove `doctrine/annotations` from `require` (kept in `require-dev` for static analysis and listed in `suggest` for anyone who wired the annotation factory manually)
- Deprecate `AnnotationLoggableContextCollectionFactory` for removal in 2.0, with a runtime deprecation via the new `symfony/deprecation-contracts` dependency
- Add `UPGRADE-2.0.md` documenting the migration to the `#[Loggable]` attribute
- Add a **Tests matrix** CI workflow: PHP 8.2/8.3/8.4 against Symfony 6.4 and 7.4 (via flex `SYMFONY_REQUIRE`) with Elasticsearch 7.17. Existing workflows are untouched
- README wording: the `Loggable` class is a PHP attribute, no longer described as an annotation

## Verification

- Full PHPUnit suite (24 tests, 53 assertions) passes against Elasticsearch 7.17 on both Symfony 6.4.42 and 7.4.14
- PHPStan reports no errors; PHP-CS-Fixer reports 0 fixable files; `composer validate --strict` passes
- The annotation factory was confirmed unregistered in the service configuration, so removing its dependency changes no default behavior
