### PR TITLE
feat!: add Symfony 8 and DoctrineBundle 3 support

### DIFF
--- a/.github/workflows/tests-matrix.yaml
+++ b/.github/workflows/tests-matrix.yaml
@@ -22,6 +22,14 @@ jobs:
                       symfony: '7.4.*'
                       elasticsearch: '9.0.0'
                       es-client: '^9.0'
+                    - php: '8.4'
+                      symfony: '8.1.*'
+                      elasticsearch: '9.0.0'
+                      es-client: '^9.0'
+                    - php: '8.4'
+                      symfony: '8.1.*'
+                      elasticsearch: '8.17.0'
+                      es-client: '^8.0'
         steps:
             - name: Runs Elasticsearch
               run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Support for Symfony 8 and DoctrineBundle 3 (`symfony/*` now `^6.4 || ^7.0 || ^8.0`, `doctrine/doctrine-bundle` now `^2.8 || ^3.0`), with Symfony 8 CI legs
 - Basic auth (`elastic_user`, `elastic_password`) and `elastic_ssl_verification` config options for secured Elasticsearch clusters (originally proposed in #26 by @jakubdusek)
 - Tests matrix now also runs against Elasticsearch 9
 
 ### Changed
+- **Breaking:** serializer attributes moved from the `Symfony\Component\Serializer\Annotation` namespace (removed in Symfony 8) to `Symfony\Component\Serializer\Attribute`; update the `Groups` import on your loggable entities
+- **Breaking:** `ActivityLogDoctrineSubscriber` no longer implements DoctrineBundle's `EventSubscriberInterface` (removed in DoctrineBundle 3) and is registered as per-event `doctrine.event_listener` instead
 - **Breaking:** migrated to the modern bundle directory layout: service configuration moved from `src/Resources/config/` to `config/`, and the bundle now extends `AbstractBundle`; the `LocasticLoggasticExtension` and `Configuration` classes were removed (see UPGRADE-2.0.md)
 - **Breaking:** upgraded to `elasticsearch/elasticsearch` `^8.0 || ^9.0`; Elasticsearch 7 servers are no longer supported and a PSR-18 HTTP client implementation is required (see UPGRADE-2.0.md)
 - **Breaking:** `ElasticsearchClientInterface::getClient()` now returns `Elastic\Elasticsearch\Client` instead of `Elasticsearch\Client`

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Each tracked entity will have two indexes in the ElasticSearch:
 System requirements
 -------------------
 
-Elasticsearch version 7.17
+- PHP 8.2+ with Symfony 6.4, 7.x or 8.x (Symfony 8 requires PHP 8.4)
+- Elasticsearch 8 or 9
 
 Installation
 ------------
@@ -83,7 +84,7 @@ You can add them to the relations and their fields too.
 namespace App\Entity;
 
 use Locastic\Loggastic\Annotation\Loggable;
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 
 #[Loggable(groups: ['blog_post_log'])]
 class BlogPost
@@ -108,7 +109,7 @@ Example for logging fields from relations:
 namespace App\Entity;
 
 use Locastic\Loggastic\Annotation\Loggable;
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 
 class Tag
 {

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -3,6 +3,23 @@
 This document collects the breaking changes planned for 2.0. Each entry lists
 the deprecation shipped in a 1.x release so you can migrate before upgrading.
 
+## Symfony 8 and serializer attributes
+
+- Symfony 8 is now supported (`^6.4 || ^7.0 || ^8.0`), together with
+  DoctrineBundle 3. On Symfony 8 stacks Doctrine uses PHP 8.4 native lazy
+  objects; the previous `symfony/var-exporter < 8.0` restriction is gone.
+- Import `Groups` from `Symfony\Component\Serializer\Attribute` instead of
+  `Symfony\Component\Serializer\Annotation` on your loggable entities. The
+  `Annotation` namespace was removed in Symfony 8; the `Attribute` namespace
+  exists since Symfony 6.4, so this change is safe on every supported
+  version. On Symfony 8, entities still using the old import are silently
+  not logged (the group metadata is invisible), so update the imports before
+  upgrading.
+- `ActivityLogDoctrineSubscriber` no longer implements DoctrineBundle's
+  `EventSubscriberInterface` (removed in DoctrineBundle 3). It is registered
+  via per-event `doctrine.event_listener` tags. If you decorated or replaced
+  this service, mirror that registration.
+
 ## Bundle structure
 
 - The bundle uses the modern directory layout: service configuration lives in

--- a/composer.json
+++ b/composer.json
@@ -11,35 +11,35 @@
   ],
   "require": {
     "php": ">=8.2",
-    "doctrine/doctrine-bundle": "^2.8",
+    "doctrine/doctrine-bundle": "^2.8 || ^3.0",
     "doctrine/orm": "^3.4",
     "elasticsearch/elasticsearch": "^8.0 || ^9.0",
     "symfony/deprecation-contracts": "^3.0",
-    "symfony/expression-language": "^6.4 || ^7.0",
-    "symfony/framework-bundle": "^6.4 || ^7.0",
-    "symfony/messenger": "^6.4 || ^7.0",
-    "symfony/property-info": "^6.4 || ^7.0",
-    "symfony/serializer": "^6.4 || ^7.0",
-    "symfony/validator": "^6.4 || ^7.0",
-    "symfony/yaml": "^6.4 || ^7.0",
+    "symfony/expression-language": "^6.4 || ^7.0 || ^8.0",
+    "symfony/framework-bundle": "^6.4 || ^7.0 || ^8.0",
+    "symfony/messenger": "^6.4 || ^7.0 || ^8.0",
+    "symfony/property-info": "^6.4 || ^7.0 || ^8.0",
+    "symfony/serializer": "^6.4 || ^7.0 || ^8.0",
+    "symfony/validator": "^6.4 || ^7.0 || ^8.0",
+    "symfony/yaml": "^6.4 || ^7.0 || ^8.0",
     "ext-simplexml": "*",
-    "symfony/security-bundle": "^6.4 || ^7.0",
-    "symfony/finder": "^6.4 || ^7.0"
+    "symfony/security-bundle": "^6.4 || ^7.0 || ^8.0",
+    "symfony/finder": "^6.4 || ^7.0 || ^8.0"
   },
   "require-dev": {
     "doctrine/annotations": "^2.0",
-    "symfony/browser-kit": "^6.4 || ^7.0",
-    "symfony/css-selector": "^6.4 || ^7.0",
-    "symfony/console": "^6.4 || ^7.0",
-    "symfony/dotenv": "^6.4 || ^7.0",
-    "symfony/phpunit-bridge": "^6.4 || ^7.0",
-    "symfony/runtime": "^6.4 || ^7.0",
+    "symfony/browser-kit": "^6.4 || ^7.0 || ^8.0",
+    "symfony/css-selector": "^6.4 || ^7.0 || ^8.0",
+    "symfony/console": "^6.4 || ^7.0 || ^8.0",
+    "symfony/dotenv": "^6.4 || ^7.0 || ^8.0",
+    "symfony/phpunit-bridge": "^6.4 || ^7.0 || ^8.0",
+    "symfony/runtime": "^6.4 || ^7.0 || ^8.0",
     "symfony/test-pack": "1.1.0",
     "phpstan/phpstan": "^2.2",
     "phpstan/phpstan-symfony": "^2.0",
     "phpstan/extension-installer": "^1.4",
     "friendsofphp/php-cs-fixer": "^3.95",
-    "symfony/http-client": "^6.4 || ^7.0",
+    "symfony/http-client": "^6.4 || ^7.0 || ^8.0",
     "nyholm/psr7": "^1.8"
   },
   "prefer-stable": true,
@@ -56,8 +56,7 @@
     }
   },
   "conflict": {
-    "symfony/translations-contracts": "<2.0",
-    "symfony/var-exporter": ">=8.0"
+    "symfony/translations-contracts": "<2.0"
   },
   "suggest": {
     "doctrine/annotations": "To configure loggable classes with the legacy @Loggable annotation (deprecated, use the PHP attribute instead)",

--- a/config/activity_log_doctrine_subscriber.yaml
+++ b/config/activity_log_doctrine_subscriber.yaml
@@ -2,4 +2,8 @@ services:
     Locastic\Loggastic\EventSubscriber\ActivityLogDoctrineSubscriber:
         autowire: true
         tags:
-            - name: 'doctrine.event_subscriber'
+            - { name: 'doctrine.event_listener', event: 'preRemove' }
+            - { name: 'doctrine.event_listener', event: 'postUpdate' }
+            - { name: 'doctrine.event_listener', event: 'postRemove' }
+            - { name: 'doctrine.event_listener', event: 'prePersist' }
+            - { name: 'doctrine.event_listener', event: 'postFlush' }

--- a/src/EventSubscriber/ActivityLogDoctrineSubscriber.php
+++ b/src/EventSubscriber/ActivityLogDoctrineSubscriber.php
@@ -2,34 +2,24 @@
 
 namespace Locastic\Loggastic\EventSubscriber;
 
-use Doctrine\Bundle\DoctrineBundle\EventSubscriber\EventSubscriberInterface;
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Event\PostRemoveEventArgs;
 use Doctrine\ORM\Event\PostUpdateEventArgs;
 use Doctrine\ORM\Event\PrePersistEventArgs;
 use Doctrine\ORM\Event\PreRemoveEventArgs;
-use Doctrine\ORM\Events;
-use Locastic\Loggastic\Logger\ActivityLogger;
+use Locastic\Loggastic\Logger\ActivityLoggerInterface;
 use Locastic\Loggastic\Util\ClassUtils;
 
-final class ActivityLogDoctrineSubscriber implements EventSubscriberInterface
+// registered as a doctrine.event_listener for each handled event, see
+// config/activity_log_doctrine_subscriber.yaml (DoctrineBundle 3 removed
+// event subscribers)
+final class ActivityLogDoctrineSubscriber
 {
     private array $persistedEntities = [];
 
     public function __construct(
-        private readonly ActivityLogger $activityLogger,
+        private readonly ActivityLoggerInterface $activityLogger,
     ) {
-    }
-
-    public function getSubscribedEvents(): array
-    {
-        return [
-            Events::preRemove,
-            Events::postUpdate,
-            Events::postRemove,
-            Events::prePersist,
-            Events::postFlush,
-        ];
     }
 
     public function preRemove(PreRemoveEventArgs $args): void

--- a/src/Model/Input/ActivityLogInput.php
+++ b/src/Model/Input/ActivityLogInput.php
@@ -2,7 +2,7 @@
 
 namespace Locastic\Loggastic\Model\Input;
 
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 
 class ActivityLogInput implements ActivityLogInputInterface
 {

--- a/src/Model/Input/CurrentDataTrackerInput.php
+++ b/src/Model/Input/CurrentDataTrackerInput.php
@@ -2,7 +2,7 @@
 
 namespace Locastic\Loggastic\Model\Input;
 
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 
 /**
  * Save the latest data for each object, so it can be used to compare changes

--- a/src/Model/Output/ActivityLog.php
+++ b/src/Model/Output/ActivityLog.php
@@ -2,7 +2,7 @@
 
 namespace Locastic\Loggastic\Model\Output;
 
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 
 class ActivityLog implements ActivityLogInterface
 {

--- a/src/Model/Output/CurrentDataTracker.php
+++ b/src/Model/Output/CurrentDataTracker.php
@@ -2,7 +2,7 @@
 
 namespace Locastic\Loggastic\Model\Output;
 
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 
 /**
  * Save the latest data for each object, so it can be used to compare changes

--- a/tests/Fixtures/app/AppKernel.php
+++ b/tests/Fixtures/app/AppKernel.php
@@ -46,7 +46,7 @@ class AppKernel extends Kernel
 
         // DoctrineBundle 3 (Symfony 8 stacks) removed this option in favor of
         // PHP 8.4 native lazy objects; DoctrineBundle 2 still needs it
-        if (\Composer\InstalledVersions::satisfies(new \Composer\Semver\VersionParser(), 'doctrine/doctrine-bundle', '^2.0')) {
+        if (Composer\InstalledVersions::satisfies(new Composer\Semver\VersionParser(), 'doctrine/doctrine-bundle', '^2.0')) {
             $container->extension('doctrine', ['orm' => ['auto_generate_proxy_classes' => true]]);
         }
     }

--- a/tests/Fixtures/app/AppKernel.php
+++ b/tests/Fixtures/app/AppKernel.php
@@ -43,5 +43,11 @@ class AppKernel extends Kernel
 
         $container->import($configDir.'/{packages}/*.{php,yaml}');
         $container->import($configDir.'/*.yaml');
+
+        // DoctrineBundle 3 (Symfony 8 stacks) removed this option in favor of
+        // PHP 8.4 native lazy objects; DoctrineBundle 2 still needs it
+        if (\Composer\InstalledVersions::satisfies(new \Composer\Semver\VersionParser(), 'doctrine/doctrine-bundle', '^2.0')) {
+            $container->extension('doctrine', ['orm' => ['auto_generate_proxy_classes' => true]]);
+        }
     }
 }

--- a/tests/Fixtures/app/Model/DummyBlogPost.php
+++ b/tests/Fixtures/app/Model/DummyBlogPost.php
@@ -5,7 +5,7 @@ namespace Locastic\Loggastic\Tests\Fixtures\App\Model;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Locastic\Loggastic\Annotation\Loggable;
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 
 #[Loggable(groups: ['dummy_blog_post_log'])]
 class DummyBlogPost

--- a/tests/Fixtures/app/Model/DummyCategory.php
+++ b/tests/Fixtures/app/Model/DummyCategory.php
@@ -2,7 +2,7 @@
 
 namespace Locastic\Loggastic\Tests\Fixtures\App\Model;
 
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 
 class DummyCategory
 {

--- a/tests/Fixtures/app/Model/DummyPhoto.php
+++ b/tests/Fixtures/app/Model/DummyPhoto.php
@@ -2,7 +2,7 @@
 
 namespace Locastic\Loggastic\Tests\Fixtures\App\Model;
 
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 
 class DummyPhoto
 {

--- a/tests/Fixtures/app/Model/DummyProduct.php
+++ b/tests/Fixtures/app/Model/DummyProduct.php
@@ -3,7 +3,7 @@
 namespace Locastic\Loggastic\Tests\Fixtures\App\Model;
 
 use Locastic\Loggastic\Annotation\Loggable;
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 
 #[Loggable(groups: ['dummy_product_log'])]
 class DummyProduct

--- a/tests/Fixtures/app/config/packages/doctrine.yaml
+++ b/tests/Fixtures/app/config/packages/doctrine.yaml
@@ -2,8 +2,7 @@ parameters:
     env(DATABASE_URL): mysql://root:@localhost/loggastic_test
 
 doctrine:
-    orm:
-        auto_generate_proxy_classes: '%kernel.debug%'
+    orm: ~
     dbal:
         driver: pdo_mysql
         url: '%env(resolve:DATABASE_URL)%'


### PR DESCRIPTION
| Q             | A
|---------------|---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

## Problem

The bundle caps at Symfony 7.x. Symfony 8 has been out since November 2025 and apps upgrading to it cannot install Loggastic. Supporting it surfaced three ecosystem changes: DoctrineBundle 3 (the Symfony 8 compatible line) removed event subscribers and the proxy option, Symfony 8 removed the `Serializer\Annotation` namespace, and var-exporter 8 removed LazyGhost.

## Changes

- Widen `symfony/*` to `^6.4 || ^7.0 || ^8.0` and `doctrine/doctrine-bundle` to `^2.8 || ^3.0`; remove the `symfony/var-exporter < 8.0` conflict (Symfony 8 stacks use PHP 8.4 native lazy objects via DoctrineBundle 3)
- **Breaking:** serializer attributes now import from `Symfony\Component\Serializer\Attribute` (the `Annotation` namespace is gone in Symfony 8). Users must update the `Groups` import on loggable entities; on Symfony 8 the old import silently disables logging for that entity, so this is called out prominently in UPGRADE-2.0.md
- **Breaking:** `ActivityLogDoctrineSubscriber` no longer implements DoctrineBundle's removed `EventSubscriberInterface`; it registers via per-event `doctrine.event_listener` tags (supported by both bundle majors) and now takes `ActivityLoggerInterface`
- Two Symfony 8.1 CI legs (against Elasticsearch 8.17 and 9.0); README system requirements updated (including a stale "Elasticsearch 7.17" note that predated #37)

## Verification

- Full suite (24 tests, 53 assertions) green on Symfony 8.1 + DoctrineBundle 3.2 + PHP 8.4 native lazy objects against Elasticsearch 9.0
- Full suite green on Symfony 6.4 + DoctrineBundle 2.18 with PHP 8.2 platform pinning, confirming the listener-tag registration and `Attribute` imports work on the oldest supported stack
- The "old import silently disables logging" failure mode was observed directly during development: with `Annotation\Groups`, update logs stopped being written because group metadata became invisible to the serializer
- PHPStan clean, PHP-CS-Fixer clean, `composer validate --strict` passes
