### PR TITLE
fix: skip update logs for items whose identifier was cleared on removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `ElasticsearchService::getItemById()` always returned null because it compared the hit total against an integer while Elasticsearch returns an object
+- Deleting an entity together with its `LoggableChildInterface` children crashed the update handler: the child's delete log triggers an update log for the parent, whose identifier Doctrine has already cleared; such updates are now skipped
 
 ## [1.2.0] - 2026-07-02
 

--- a/src/MessageHandler/UpdateActivityLogHandler.php
+++ b/src/MessageHandler/UpdateActivityLogHandler.php
@@ -31,6 +31,14 @@ final class UpdateActivityLogHandler
             return;
         }
 
+        // the item was removed in the meantime (e.g. a LoggableChildInterface
+        // logging to a parent that was deleted in the same flush); Doctrine
+        // clears generated identifiers on removal, and an item without an
+        // identifier has no current data tracker to compare against
+        if (null === $updatedItem->getId()) {
+            return;
+        }
+
         $currentDataTracker = $this->currentDataTrackerProvider->getCurrentDataTrackerByClassAndId($message->getClassName(), $updatedItem->getId());
 
         if (!$currentDataTracker instanceof CurrentDataTrackerInterface) {

--- a/tests/UnitTests/MessageHandler/UpdateActivityLogHandlerTest.php
+++ b/tests/UnitTests/MessageHandler/UpdateActivityLogHandlerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Locastic\Loggastic\Tests\UnitTests\MessageHandler;
+
+use Locastic\Loggastic\DataProcessor\ActivityLogProcessorInterface;
+use Locastic\Loggastic\DataProvider\CurrentDataTrackerProviderInterface;
+use Locastic\Loggastic\Message\UpdateActivityLogMessage;
+use Locastic\Loggastic\MessageHandler\UpdateActivityLogHandler;
+use Locastic\Loggastic\Metadata\LoggableContext\Factory\LoggableContextCollectionFactoryInterface;
+use Locastic\Loggastic\Metadata\LoggableContext\Factory\LoggableContextFactory;
+use Locastic\Loggastic\Metadata\LoggableContext\LoggableContextCollection;
+use PHPUnit\Framework\TestCase;
+
+class UpdateActivityLogHandlerTest extends TestCase
+{
+    public function testItSkipsItemsWithoutAnIdentifier(): void
+    {
+        $item = new class {
+            public function getId(): ?int
+            {
+                return null;
+            }
+        };
+
+        $collectionFactory = $this->createMock(LoggableContextCollectionFactoryInterface::class);
+        $collectionFactory->method('create')->willReturn(
+            new LoggableContextCollection([$item::class => ['groups' => ['test_log']]])
+        );
+
+        $currentDataTrackerProvider = $this->createMock(CurrentDataTrackerProviderInterface::class);
+        $currentDataTrackerProvider->expects(self::never())->method('getCurrentDataTrackerByClassAndId');
+
+        $activityLogProcessor = $this->createMock(ActivityLogProcessorInterface::class);
+        $activityLogProcessor->expects(self::never())->method('processUpdatedItem');
+
+        $handler = new UpdateActivityLogHandler(
+            $activityLogProcessor,
+            $currentDataTrackerProvider,
+            new LoggableContextFactory($collectionFactory)
+        );
+
+        $handler(new UpdateActivityLogMessage($item));
+    }
+}


### PR DESCRIPTION
| Q             | A
|---------------|---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Issues        | -
| License       | MIT

## Problem

Deleting a parent entity together with its `LoggableChildInterface` children crashes the update handler. The child's delete log triggers an update log for the parent (`ActivityLogger::handleLoggableChild()`), but by then Doctrine has already cleared the parent's generated identifier. The current data tracker lookup then runs a term query with `objectId: null`, which Elasticsearch rejects with `400 illegal_argument_exception: field name is null or empty`, failing the whole flush flow.

Found while driving a real application (demo app with `Product` -> `ProductVariant` as loggable child) against 2.0-dev.

## Changes

- `UpdateActivityLogHandler` returns early when the updated item's identifier is null: an item without an identifier has no current data tracker to compare against, its own delete log is already written, and an edit log for a removed entity is meaningless
- Unit test asserting the tracker provider and processor are never called for an identifier-less item

## Verification

- Reproduced in the demo app: delete of a product with variants failed with the 400 before the fix and completes after it, with the expected Created/Edited/Deleted logs intact
- Full PHPUnit suite (25 tests, 55 assertions) green against Elasticsearch 9.0; PHPStan clean; PHP-CS-Fixer clean