### PR TITLE
fix(elasticsearch): refresh the index on bulkCreate like single-item writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `ElasticsearchService::getItemById()` always returned null because it compared the hit total against an integer while Elasticsearch returns an object
+- `ElasticsearchService::bulkCreate()` now refreshes the index like `createItem()` and `updateItem()` already do; previously, current data trackers written by the populate command were not immediately searchable, so updates arriving right after population were silently dropped
 
 ## [1.2.0] - 2026-07-02
 

--- a/src/Bridge/Elasticsearch/ElasticsearchService.php
+++ b/src/Bridge/Elasticsearch/ElasticsearchService.php
@@ -53,6 +53,7 @@ final class ElasticsearchService implements ElasticsearchServiceInterface
         $request = [
             'index' => $index,
             'body' => $params,
+            'refresh' => 'true',
         ];
 
         $this->elasticsearchClient->getClient()->bulk($request);


### PR DESCRIPTION
| Q             | A
|---------------|---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Issues        | -
| License       | MIT

## Problem

`ElasticsearchService::createItem()` and `updateItem()` request `refresh=true`, so written documents are immediately searchable, and the update flow relies on that (create -> immediate update reads the tracker back). `bulkCreate()` does not refresh, so current data trackers written by `locastic:activity-logs:populate-current-data-trackers` are invisible to the tracker lookup until Elasticsearch refreshes on its own (default 1s). Update logs arriving in that window are silently dropped: the handler finds no tracker and returns early, meaning the very first change after repopulating trackers can go unlogged.

Found running a backend-parity harness against a demo app: a populate-then-update sequence logged the change on a relational storage adapter but dropped it on Elasticsearch.

## Changes

- `bulkCreate()` sends `refresh: 'true'`, consistent with the other write methods. Populate runs in batches of 250 per message, so one refresh per batch is a negligible cost for an occasional admin operation

## Verification

- The parity harness (create trackers via populate, update the entity immediately, expect an Edited log with the correct diff) fails on Elasticsearch 9.0 before this change and passes after; the same harness passes on the relational adapter both times
- Full PHPUnit suite (24 tests, 53 assertions) green against Elasticsearch 9.0; PHP-CS-Fixer clean