### PR TITLE
chore: prepare 2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.1.0] - 2026-07-07
 
 ### Added
 - `storage` configuration option to select the storage backend: `elasticsearch` (default), `doctrine` or `in_memory`; when a non-Elasticsearch backend is selected, no Elasticsearch services are registered

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "2.1-dev"
+      "dev-master": "2.2-dev"
     }
   },
   "conflict": {


### PR DESCRIPTION
| Q             | A
|---------------|---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Issues        | -
| License       | MIT

## Problem

#45 (Doctrine DBAL + in-memory storage adapters, `storage` config option) is merged and CI is green on the full matrix, so master is ready to ship as a minor release.

## Changes

- Stamps the changelog: Unreleased section becomes `2.1.0 - 2026-07-07`
- Bumps the `dev-master` branch alias from `2.1-dev` to `2.2-dev`

## Verification

- `composer validate --strict` passes
- No code changes; release content is what already passed the full matrix on #45

After merge: tag `v2.1.0` on the merge commit, publish the GitHub release, then watch Packagist pickup.